### PR TITLE
Add button, backend, and shortcut to respawn golem with previouse settings (#1)

### DIFF
--- a/GolemHelper/Automation/AutomationLogic.cpp
+++ b/GolemHelper/Automation/AutomationLogic.cpp
@@ -386,3 +386,42 @@ void AutomationLogic::RespawnGolem() {
 
     g_api->Log(ELogLevel_INFO, "GolemHelper", "Golem respawn sequence completed!");
 }
+
+void AutomationLogic::RemoveAndRespawnGolem()
+{
+    if (!g_api || !g_state.enabled) return;
+
+    bool uiWasVisible = g_state.showUI;
+    if (uiWasVisible) {
+        g_state.showUI = false;
+    }
+
+    g_api->Log(ELogLevel_INFO, "GolemHelper", "Starting golem remove and respawn sequence (3 steps)");
+
+    try {
+        g_api->GameBinds.InvokeAsync(EGameBinds_MiscInteract, 50);
+        Sleep(g_state.initialDelay);
+
+        for (int i = 0; i < MenuSequences::GOLEM_REMOVE_AND_RESPAWN_LENGTH; i++) {
+            MenuOption step = MenuSequences::GOLEM_REMOVE_AND_RESPAWN[i];
+            auto coordIt = g_coords.coords.find(step);
+
+            if (coordIt == g_coords.coords.end() ||
+                (coordIt->second.first == 0 && coordIt->second.second == 0)) {
+                continue;
+                }
+
+            int delay = (i == MenuSequences::GOLEM_REMOVE_AND_RESPAWN_LENGTH - 1) ? 50 : g_state.stepDelay;
+            CoordinateUtils::ClickAtScaled(coordIt->second.first, coordIt->second.second, delay);
+        }
+    }
+    catch (...) {
+        g_api->Log(ELogLevel_WARNING, "GolemHelper", "Exception during golem remove and respawn sequence");
+    }
+
+    if (uiWasVisible) {
+        g_state.showUI = true;
+    }
+
+    g_api->Log(ELogLevel_INFO, "GolemHelper", "Golem remove and respawn sequence completed!");
+}

--- a/GolemHelper/Automation/AutomationLogic.h
+++ b/GolemHelper/Automation/AutomationLogic.h
@@ -8,4 +8,5 @@ public:
     static void ApplyHealerBoons();
     static void SpawnGolem();
     static void RespawnGolem();
+    static void RemoveAndRespawnGolem();
 };

--- a/GolemHelper/Common/MenuSequences.h
+++ b/GolemHelper/Common/MenuSequences.h
@@ -72,8 +72,15 @@ public:
         GOLEM_EXIT
     };
 
+    static constexpr MenuOption GOLEM_REMOVE_AND_RESPAWN[3] = {
+        GOLEM_REMOVEGOLEM,
+        GOLEM_RESPAWNMYPREVIOUSGOLEMINCARNATION,
+        GOLEM_EXIT
+    };
+
     static constexpr int BOON_LENGTH = 20;
     static constexpr int HEALER_QUICK_LENGTH = 10;
     static constexpr int GOLEM_LENGTH = 25;
     static constexpr int GOLEM_RESPAWN_LENGTH = 2;
+    static constexpr int GOLEM_REMOVE_AND_RESPAWN_LENGTH = 3;
 };

--- a/GolemHelper/Common/Types.h
+++ b/GolemHelper/Common/Types.h
@@ -52,6 +52,7 @@ enum MenuOption {
 
     // === GOLEM MENU ===
     GOLEM_RESPAWNMYPREVIOUSGOLEMINCARNATION,
+    GOLEM_REMOVEGOLEM,
     GOLEM_SPAWNAGOLEM,
     GOLEM_HITBOX_SMALL,
     GOLEM_HITBOX_MEDIUM,
@@ -196,6 +197,7 @@ struct MenuCoordinates {
 
             // === GOLEM MENU ===
             {GOLEM_RESPAWNMYPREVIOUSGOLEMINCARNATION, {830, 352}},
+            {GOLEM_REMOVEGOLEM, {830, 306}},
             {GOLEM_SPAWNAGOLEM, {830, 260}},
             {GOLEM_HITBOX_SMALL, {830, 260}},
             {GOLEM_HITBOX_MEDIUM, {830, 305}},

--- a/GolemHelper/Input/KeybindManager.cpp
+++ b/GolemHelper/Input/KeybindManager.cpp
@@ -12,6 +12,7 @@ void KeybindManager::RegisterKeybinds() {
     g_api->InputBinds.RegisterWithStruct("GolemHelper.ApplyBoons", HandleBoonKeybind, kb_empty);
     g_api->InputBinds.RegisterWithStruct("GolemHelper.SpawnGolem", HandleGolemKeybind, kb_empty);
     g_api->InputBinds.RegisterWithStruct("GolemHelper.RespawnGolem", HandleRespawnGolemKeybind, kb_empty);
+    g_api->InputBinds.RegisterWithStruct("GolemHelper.RemoveAndRespawnGolem", HandleRemoveAndRespawnGolemKeybind, kb_empty);
     g_api->InputBinds.RegisterWithStruct("GolemHelper.QuickDPS", HandleQuickDpsKeybind, kb_empty);
     g_api->InputBinds.RegisterWithStruct("GolemHelper.AlacDPS", HandleAlacDpsKeybind, kb_empty);
     g_api->InputBinds.RegisterWithStruct("GolemHelper.Toggle", HandleToggleKeybind, kb_empty);
@@ -25,6 +26,7 @@ void KeybindManager::UnregisterKeybinds() {
     g_api->InputBinds.Deregister("GolemHelper.ApplyBoons");
     g_api->InputBinds.Deregister("GolemHelper.SpawnGolem");
     g_api->InputBinds.Deregister("GolemHelper.RespawnGolem");
+    g_api->InputBinds.Deregister("GolemHelper.RemoveAndRespawnGolem"); 
     g_api->InputBinds.Deregister("GolemHelper.QuickDPS");
     g_api->InputBinds.Deregister("GolemHelper.AlacDPS");
     g_api->InputBinds.Deregister("GolemHelper.Toggle");
@@ -47,6 +49,12 @@ void KeybindManager::HandleGolemKeybind(const char* id, bool release) {
 void KeybindManager::HandleRespawnGolemKeybind(const char* id, bool release) {
     if (!release && g_state.enabled) {
         AutomationLogic::RespawnGolem();
+    }
+}
+
+void KeybindManager::HandleRemoveAndRespawnGolemKeybind(const char* id, bool release) {
+    if (!release && g_state.enabled) {
+        AutomationLogic::RemoveAndRespawnGolem();
     }
 }
 

--- a/GolemHelper/Input/KeybindManager.h
+++ b/GolemHelper/Input/KeybindManager.h
@@ -8,6 +8,7 @@ public:
     static void HandleBoonKeybind(const char* id, bool release);
     static void HandleGolemKeybind(const char* id, bool release);
     static void HandleRespawnGolemKeybind(const char* id, bool release);
+    static void HandleRemoveAndRespawnGolemKeybind(const char* id, bool release);
     static void HandleQuickDpsKeybind(const char* id, bool release);
     static void HandleAlacDpsKeybind(const char* id, bool release);
     static void HandleToggleKeybind(const char* id, bool release);

--- a/GolemHelper/UI/UIManager.cpp
+++ b/GolemHelper/UI/UIManager.cpp
@@ -173,6 +173,11 @@ void UIManager::RenderSettingsTab() {
             g_api->InputBinds.Invoke("GolemHelper.RespawnGolem", false);
         }
     }
+    if (ImGui::Button("Remove and Respawn", ImVec2(150, 0))) {
+        if (g_state.enabled && MapUtils::IsInTrainingArea()) {
+            g_api->InputBinds.Invoke("GolemHelper.RemoveAndRespawnGolem", false);
+        }
+    }
 
     ImGui::Text("Golem Hitbox:");
 


### PR DESCRIPTION
This PR adds a UI button, a keyboard shortcut, and backend to remove and respawn a golem, as requested in #1. All previous settings remain unchanged.